### PR TITLE
don't to perform download if url is "" but not nil

### DIFF
--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -133,7 +133,7 @@
         isFailedUrl = [self.failedURLs containsObject:url];
     }
 
-    if (!url || (!(options & SDWebImageRetryFailed) && isFailedUrl)) {
+    if (url.absoluteString.length == 0 || (!(options & SDWebImageRetryFailed) && isFailedUrl)) {
         dispatch_main_sync_safe(^{
             NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorFileDoesNotExist userInfo:nil];
             completedBlock(nil, error, SDImageCacheTypeNone, YES, url);


### PR DESCRIPTION
sometimes user may pass @"" as url to sdwebimage to download, now it will also run NSURLConnection and try to download, actually there is no need to do this. I think maybe use url.absoluteString.length == 0 to avoid that url is not nil but a empty string will be better
